### PR TITLE
append a newline to the LinodeException message

### DIFF
--- a/linode/api.py
+++ b/linode/api.py
@@ -12,7 +12,7 @@ logger = logging.getLogger('linode.api')
 class LinodeException(Exception):
     def __init__(self, action, error_array):
         for err in error_array:
-            sys.stderr.write('[{0}] {1}'.format(action, err.get('ERRORMESSAGE')))
+            sys.stderr.write('[{0}] {1}\n'.format(action, err.get('ERRORMESSAGE')))
 
 
 class Worker(object):


### PR DESCRIPTION
```
[domain.list.lol] The requested class does not exist
Traceback (most recent call last):
  File "/tmp/bleh", line 4, in <module>
    for domain in linode.domain.list.lol():
  File "/Users/jchen/.venvs/linode/lib/python3.4/site-packages/linode-0.4.1-py3.4.egg/linode/api.py", line 27, in __call__
  File "/Users/jchen/.venvs/linode/lib/python3.4/site-packages/linode-0.4.1-py3.4.egg/linode/api.py", line 76, in _worker_func
  File "/Users/jchen/.venvs/linode/lib/python3.4/site-packages/linode-0.4.1-py3.4.egg/linode/api.py", line 69, in _request
linode.api.LinodeException: ('domain.list.lol', [{'ERRORMESSAGE': 'The requested class does not exist', 'ERRORCODE': 3}])
```
